### PR TITLE
fixed typo: backpropogation -> backpropagation

### DIFF
--- a/ODSC_Deep_Learning_2017.ipynb
+++ b/ODSC_Deep_Learning_2017.ipynb
@@ -156,7 +156,7 @@
     }
    },
    "source": [
-    "* We'll implement a basic neural net with one hidden layer, from scratch, and use mathematical principles to get the backpropogation right."
+    "* We'll implement a basic neural net with one hidden layer, from scratch, and use mathematical principles to get the backpropagation right."
    ]
   },
   {
@@ -1623,7 +1623,7 @@
     }
    },
    "source": [
-    "### Backpropogation - step 1:"
+    "### Backpropagation - step 1:"
    ]
   },
   {
@@ -1693,7 +1693,7 @@
     }
    },
    "source": [
-    "## Backpropogation - step 2:"
+    "## Backpropagation - step 2:"
    ]
   },
   {
@@ -1758,7 +1758,7 @@
     }
    },
    "source": [
-    "### Backpropogation - step 2:"
+    "### Backpropagation - step 2:"
    ]
   },
   {
@@ -1786,7 +1786,7 @@
     }
    },
    "source": [
-    "### Backpropogation - step 2:"
+    "### Backpropagation - step 2:"
    ]
   },
   {
@@ -1856,7 +1856,7 @@
     }
    },
    "source": [
-    "### Backpropogation - step 3:"
+    "### Backpropagation - step 3:"
    ]
   },
   {
@@ -1880,7 +1880,7 @@
     }
    },
    "source": [
-    "### Backpropogation - step 3:"
+    "### Backpropagation - step 3:"
    ]
   },
   {
@@ -1911,7 +1911,7 @@
     }
    },
    "source": [
-    "### Backpropogation - step 3:"
+    "### Backpropagation - step 3:"
    ]
   },
   {
@@ -1939,7 +1939,7 @@
     }
    },
    "source": [
-    "### Backpropogation - step 3:"
+    "### Backpropagation - step 3:"
    ]
   },
   {
@@ -1974,7 +1974,7 @@
     }
    },
    "source": [
-    "### Backpropogation - step 3:"
+    "### Backpropagation - step 3:"
    ]
   },
   {
@@ -2018,7 +2018,7 @@
     }
    },
    "source": [
-    "### Backpropogation - step 3:"
+    "### Backpropagation - step 3:"
    ]
   },
   {
@@ -2127,7 +2127,7 @@
     }
    },
    "source": [
-    "## Backpropogation - step 4:"
+    "## Backpropagation - step 4:"
    ]
   },
   {
@@ -2164,7 +2164,7 @@
     }
    },
    "source": [
-    "### Backpropogation - step 4:"
+    "### Backpropagation - step 4:"
    ]
   },
   {
@@ -2201,7 +2201,7 @@
     }
    },
    "source": [
-    "### Backpropogation - step 4:"
+    "### Backpropagation - step 4:"
    ]
   },
   {
@@ -2271,7 +2271,7 @@
     }
    },
    "source": [
-    "### Backpropogation - step 5:"
+    "### Backpropagation - step 5:"
    ]
   },
   {
@@ -2295,7 +2295,7 @@
     }
    },
    "source": [
-    "### Backpropogation - step 5:"
+    "### Backpropagation - step 5:"
    ]
   },
   {
@@ -2332,7 +2332,7 @@
     }
    },
    "source": [
-    "### Backpropogation - step 5:"
+    "### Backpropagation - step 5:"
    ]
   },
   {
@@ -2372,7 +2372,7 @@
     }
    },
    "source": [
-    "### Backpropogation - step 5:"
+    "### Backpropagation - step 5:"
    ]
   },
   {
@@ -2431,7 +2431,7 @@
     }
    },
    "source": [
-    "### Backpropogation - step 6:"
+    "### Backpropagation - step 6:"
    ]
   },
   {
@@ -2455,7 +2455,7 @@
     }
    },
    "source": [
-    "### Backpropogation - step 6:"
+    "### Backpropagation - step 6:"
    ]
   },
   {
@@ -2479,7 +2479,7 @@
     }
    },
    "source": [
-    "### Backpropogation - step 6:"
+    "### Backpropagation - step 6:"
    ]
   },
   {
@@ -2506,7 +2506,7 @@
     }
    },
    "source": [
-    "### Backpropogation - step 6:"
+    "### Backpropagation - step 6:"
    ]
   },
   {
@@ -2533,7 +2533,7 @@
     }
    },
    "source": [
-    "### Backpropogation - step 6:"
+    "### Backpropagation - step 6:"
    ]
   },
   {
@@ -2570,7 +2570,7 @@
     }
    },
    "source": [
-    "### Backpropogation - step 6:"
+    "### Backpropagation - step 6:"
    ]
   },
   {
@@ -2608,7 +2608,7 @@
     }
    },
    "source": [
-    "### Backpropogation - step 6:"
+    "### Backpropagation - step 6:"
    ]
   },
   {
@@ -2632,7 +2632,7 @@
     }
    },
    "source": [
-    "### Backpropogation - step 6:"
+    "### Backpropagation - step 6:"
    ]
   },
   {
@@ -2660,7 +2660,7 @@
     }
    },
    "source": [
-    "### Backpropogation - step 6:"
+    "### Backpropagation - step 6:"
    ]
   },
   {
@@ -2693,7 +2693,7 @@
     }
    },
    "source": [
-    "### Backpropogation - step 6:"
+    "### Backpropagation - step 6:"
    ]
   },
   {
@@ -2905,7 +2905,7 @@
     "    # loss\n",
     "    L = 0.5 * (y_batch - P) ** 2\n",
     "    \n",
-    "    # backpropogation\n",
+    "    # backpropagation\n",
     "    dLdP = -1.0 * (y_batch - P)\n",
     "    dPdC = sigmoid(C) * (1-sigmoid(C))\n",
     "    dLdC = dLdP * dPdC\n",
@@ -3432,8 +3432,8 @@
     "        loss = self.loss_function(prediction, Y)\n",
     "        return self.loss_function(prediction, Y, bprop=True)\n",
     "\n",
-    "    def backpropogate(self, loss):\n",
-    "        \"\"\" Backpropogate the loss through the net. \"\"\"\n",
+    "    def backpropagate(self, loss):\n",
+    "        \"\"\" Backpropagate the loss through the net. \"\"\"\n",
     "        loss_next = loss\n",
     "        for layer in reversed(self.layers):\n",
     "            loss_next = layer.bprop(loss_next)\n",
@@ -3528,7 +3528,7 @@
     }
    },
    "source": [
-    "In addition, during the forward pass and backpropogation, we use the following abbreviations:\n",
+    "In addition, during the forward pass and backpropagation, we use the following abbreviations:\n",
     "\n",
     "* LI = \"Layer Input\"\n",
     "* AI = \"Activation Input\"\n",
@@ -4223,7 +4223,7 @@
     }
    },
    "source": [
-    "Because backpropogation involves multiplying a value by the derivative of the activation function, gradients (that tell the weights how to update) get smaller and smaller as you go get further from the output layer:"
+    "Because backpropagation involves multiplying a value by the derivative of the activation function, gradients (that tell the weights how to update) get smaller and smaller as you go get further from the output layer:"
    ]
   },
   {


### PR DESCRIPTION
Altogether a very nice consolidation of terms and explanations, the typo was just distracting. In case this talk will be given again,  I believe it would benefit from the correction.